### PR TITLE
Minor grammatical fixes

### DIFF
--- a/site/design-notes/state-of-valhalla/03-vm-model.md
+++ b/site/design-notes/state-of-valhalla/03-vm-model.md
@@ -536,7 +536,7 @@ incoming value can actually be stored as a bare value.
 Arrays of reference types are covariant; if `C` is a subtype of `D`, then `[LC;`
 is a subtype of `[LD;`.  For primitive classes, we extend this covariance such
 that an array of bare values is seen as a subtype of an array of references of
-the corresponding type: `[QX;` is a subtype of `LX;` (and, since reference
+the corresponding type: `[QX;` is a subtype of `[LX;` (and, since reference
 arrays are covariant, `[QX;` is transitively a subtype of `[LObject;`.)  In
 short, the JVM replicates the language level rule, that `A[] <: B[]` if and only
 if `A extends B` (not just `A <: B`), recalling that `A extends B` means either

--- a/site/design-notes/state-of-valhalla/03-vm-model.md
+++ b/site/design-notes/state-of-valhalla/03-vm-model.md
@@ -183,7 +183,7 @@ of a `Q` type in a declared field or method is required, and may produce errors.
 The timing of class initialization (execution of `<clinit>` methods) is also
 affected by the presence of `Q` descriptors.  A default instance of a primitive
 class `Foo` is created whenever a variable of type `QFoo;` is created.  This
-means that when before array of type `[QFoo;` is created, and before an object
+means that before an array of type `[QFoo;` is created, and before an object
 containing a non-static field of type `QFoo;` is created, the class `Foo` must
 be initialized.  Also, before a static field of type `QFoo;` is first
 referenced, again `Foo` must be initialized.  (This might be when the class
@@ -472,7 +472,7 @@ grant access to these restricted instructions to other clients, on an opt-in
 basis, if this seems useful.)
 
 The `anewarray` instruction is similarly extended to apply to a `Q` descriptor;
-this determines whether the resulting array is flattened (`Q`), in which case it
+this determines whether the resulting array may be flattened (`Q`), in which case it
 is an array of bare values, or not (`L`).  The `anewarray` instruction
 returns a plain (`L`) reference to an array regardless of its component type.
 


### PR DESCRIPTION
Some minor grammatical changes and a adjusted wording to reflect that Q may be flattened but flatness isn't guaranteed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla-docs pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/valhalla-docs pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla-docs/pull/8.diff">https://git.openjdk.java.net/valhalla-docs/pull/8.diff</a>

</details>
