### PR TITLE
Fix Markdown syntax mistakes in “The Saga of the Parametric VM”

### DIFF
--- a/site/design-notes/parametric-vm/parametric-vm.md
+++ b/site/design-notes/parametric-vm/parametric-vm.md
@@ -2976,8 +2976,8 @@ a constant which is comprised of all of these elements:
 
   - The "raw" reference to _C_, a `CONSTANT_Class` constant.
   - Optionally, a parametric reference to _C_, a `CONSTANT_SpecializationLinkage`
-  - wrapping the "raw" reference to _C_, and also proposing some
-  - linkage selector value _V_.  Call this the "scope wrapper" if it's present.
+    wrapping the "raw" reference to _C_, and also proposing some
+    linkage selector value _V_.  Call this the "scope wrapper" if it's present.
   - The "raw" name and type of _M_, encoded in a
     `CONSTANT_NameAndType` constant.
   - A `CONSTANT_Methodref` (or `CONSTANT_InterfaceMethodref`) which


### PR DESCRIPTION
This is a simple typo fix for the list in [**The Saga of the Parametric VM** § Bi‑variant specialization linkage](https://openjdk.org/projects/valhalla/design-notes/parametric-vm/parametric-vm#bi-variant-specialization-linkage).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla-docs.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/valhalla-docs.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla-docs/pull/10.diff">https://git.openjdk.org/valhalla-docs/pull/10.diff</a>

</details>
