### PR TITLE
Add Brian Goetz presentation from July 2024

### DIFF
--- a/site/_index.md
+++ b/site/_index.md
@@ -55,6 +55,10 @@ We've also worked on some supplementary tasks and features, including:
 These documents and presentations present a more holistic view of the Valhalla
 project's goals and design considerations.
 
+-   [Brian Goetz: Valhalla - Where Are We?](https://www.youtube.com/watch?v=IF9l8fYfSnI) (JVM Language Summit, July 2024)
+
+-   [Dan Smith: Value Objects in Valhalla](https://www.youtube.com/watch?v=a3VRwz4zbdw) (JVM Language Summit, August 2023)
+
 -   The State of Valhalla (December 2021)
     - [1. The Road to Valhalla](design-notes/state-of-valhalla/01-background)
     - [2. The Language Model](design-notes/state-of-valhalla/02-object-model)
@@ -63,8 +67,6 @@ project's goals and design considerations.
 -   Parametric JVM
     - [Background: How We Got the Generics We Have](design-notes/in-defense-of-erasure) (June 2020)
     - [The Saga of the Parametric VM](design-notes/parametric-vm/parametric-vm) (April 2021)
-
--   [Dan Smith: Value Objects in Valhalla](https://www.youtube.com/watch?v=a3VRwz4zbdw) (JVM Language Summit, August 2023)
 
 ## Implementation
 


### PR DESCRIPTION
Looking into the present state of project Valhalla, I found a very good presentation from July of 2024 at https://inside.java/tag/valhalla that was not listed on the page at https://openjdk.org/projects/valhalla/ but seems to fit well alongside the other presentations listed there.

I updated the page to include this presentation from Brian Goetz. I also sorted the presentations in reverse chronological order, as some of the information in this 2024 presentation seems to supersede previous ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla-docs.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/valhalla-docs.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla-docs/pull/13.diff">https://git.openjdk.org/valhalla-docs/pull/13.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla-docs/pull/13#issuecomment-2598572988)
</details>
