### PR TITLE
Fix wrong link to JEP 401 and add background info links

### DIFF
--- a/site/_index.md
+++ b/site/_index.md
@@ -64,6 +64,12 @@ project's goals and design considerations.
 -   [Brian Goetz: Valhalla—Where Are We?](https://www.youtube.com/watch?v=IF9l8fYfSnI)
     (JVM Language Summit 2024)
 
+-   [Dan Smith: Variable Initialization 2.0](https://www.youtube.com/watch?v=ThtrTwooKDc)
+    (JVM Language Summit 2024)
+
+-   [John Rose: encodings for flattened heap values](https://cr.openjdk.org/~jrose/values/flattened-values.html)
+    (May 2024)
+
 -   [Dan Smith: Value Objects in Valhalla](https://www.youtube.com/watch?v=a3VRwz4zbdw)
     (JVM Language Summit 2023)
 
@@ -132,7 +138,7 @@ JEPs are under active development or have been delivered.
 JEP                            Feature              Status
 -----------------------------  -------------------  ----------------
 [JEP 401: Value Classes and    Value Classes        Submitted
-Objects (Preview)][390]
+Objects (Preview)][401]
 
 [Strict Field Initialization   Supplementary        Draft (to be
 in the JVM][8350458]                                submitted)


### PR DESCRIPTION
The link to JEP 401 pointed to 390. Unrelated, I also added a talk from Dan and an article from John to the list of background documents. Maybe they were intentionally left out, so no hard feelings if they're removed. 😉 And the GitHub editor added a trailing newline, I think. 😁

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla-docs.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/valhalla-docs.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla-docs/pull/16.diff">https://git.openjdk.org/valhalla-docs/pull/16.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla-docs/pull/16#issuecomment-3720936777)
</details>
